### PR TITLE
fix: parameters value when empty

### DIFF
--- a/argo.tf
+++ b/argo.tf
@@ -12,7 +12,7 @@ locals {
       "targetRevision" : var.helm_chart_version
       "helm" : {
         "releaseName" : var.helm_release_name
-        "parameters" : [for k, v in var.settings : tomap({ "forceString" : true, "name" : k, "value" : v })]
+        "parameters" : length(var.settings) == 0 ? null : [for k, v in var.settings : tomap({ "forceString" : true, "name" : k, "value" : v })]
         "values" : var.enabled ? data.utils_deep_merge_yaml.values[0].output : ""
       }
     }


### PR DESCRIPTION
# Description

This PR fixes following error which occurs with Kubernetes provider `>2.20.0`

```
╷
│ Error: Provider produced inconsistent result after apply
│ 
│ When applying changes to module.grafana-shared-ec1.module.grafana.kubernetes_manifest.this[0], provider "provider[\"registry.terraform.io/hashicorp/kubernetes\"]" produced an unexpected new value:
│ .object.spec.source.helm.parameters: was cty.ListValEmpty(cty.Object(map[string]cty.Type{"forceString":cty.Bool, "name":cty.String, "value":cty.String})), but now null.
│ 
│ This is a bug in the provider, which should be reported in the provider's own issue tracker.
╵
```

## Type of change

- [x] A bug fix (PR prefix `fix`)
- [ ] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

## How Has This Been Tested?

LARA
