### PR TITLE
feat(chart)!: upgrade chart to 11.3.6; app to 12.4.2

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -10,8 +10,8 @@ locals {
   addon = {
     name = "grafana"
 
-    helm_chart_version = "6.43.5"
-    helm_repo_url      = "https://grafana.github.io/helm-charts"
+    helm_chart_version = "11.3.6"
+    helm_repo_url      = "https://grafana-community.github.io/helm-charts"
   }
 
   addon_irsa = {


### PR DESCRIPTION
# Description

<!--
Please include a summary of the change, provide a justification and which issue is fixed.
-->

## Type of change

- [ ] A bug fix (PR prefix `fix`)
- [x] A new feature (PR prefix `feat`)
- [ ] A code change that neither fixes a bug nor adds a feature (PR prefix `refactor`)
- [ ] Adding missing tests or correcting existing tests (PR prefix `test`)
- [ ] Changes that do not affect the meaning of the code like white-spaces, formatting, missing semi-colons, etc. (PR prefix `style`)
- [ ] Changes to our CI configuration files and scripts (PR prefix `ci`)
- [ ] Documentation only changes (PR prefix `docs`)

⚠️ **BREAKING CHANGE** ⚠️  This pull request updates the Grafana Helm chart configuration to use a newer version and a different repository. These changes ensure we are using the latest supported chart for Grafana.

Configuration updates:

* Updated `helm_chart_version` for the Grafana addon from `"6.43.5"` to `"11.3.6" to use the latest chart version. This effectively changes Grafana version from 9.2.4 to 12.4.2. Please, follow [migration guides](https://grafana.com/docs/grafana/latest/upgrade-guide/) to migrate your installation.
* Changed the `helm_repo_url` for the Grafana addon from the official Grafana repository to the Grafana community repository which replaces previous one, see https://community.grafana.com/t/helm-repository-migration-grafana-community-charts/160983.

## How Has This Been Tested?

<!--
Please describe the tests that you ran to verify your changes.
-->

Checked if default Helm values are still valid with the new Helm chart version.